### PR TITLE
Improve metadata retrieval

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -198,14 +198,14 @@ class App:
                     time.sleep(DISCORD_STATUS_LIMIT)
                     continue
                 tab = tab[0]
-                compareTab["title"] = tab.title
-                compareTab["artwork"] = tab.artwork
-                compareTab["artist"] = tab.artist
-                compareTab["lastTime"] = tab.start
                 if tab.ad:
                     Logger.write(message="Ad detected.", origin=self)
                     time.sleep(DISCORD_STATUS_LIMIT)
                     continue
+                compareTab["title"] = tab.title
+                compareTab["artwork"] = tab.artwork
+                compareTab["artist"] = tab.artist
+                compareTab["lastTime"] = tab.start
                 if self.last_tab and self.last_tab == tab:
                     # fixed problem where it didn't detect the page change (appears to happen sometimes in playlists)
                     self.silent = self.last_tab.end + self.refreshRate < time.time()


### PR DESCRIPTION
Improved the metadata request by returning a JSON object instead of an array which had to be split using #. 

This fixes issues where metadata with any # in it's attributes would crash the application since it used that symbol as the split delimeter.
Also removed the `if "http" in self.metadata[5]:` check in `Tab.py` as it made no sense.